### PR TITLE
[Feat] MyPage 이동 버튼 추가 #17

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import MapView from './components/MapView';
 import ScanButton from './components/ScanButton';
 import StoreButton from './components/StoreButton';
+import MyPageButton from './components/MyPageButton';
 
 const DEFAULT_CENTER = [37.5665, 126.9780]; // 서울
 
@@ -159,6 +160,9 @@ export default function App() {
     <>
       <div style={{ position: 'fixed', top: 24, right: 24, zIndex: 9999 }}>
         <StoreButton />
+      </div>
+      <div style={{ position: 'fixed', top: 24, left: 24, zIndex: 9999 }}>
+        <MyPageButton />
       </div>
       <div style={{
         position: 'fixed', bottom: 24, left: '50%',

--- a/src/assets/icons/mypage.svg
+++ b/src/assets/icons/mypage.svg
@@ -1,0 +1,13 @@
+<svg width="45" height="45" viewBox="0 0 45 45" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1" y="1" width="43" height="43.0251" rx="21.5" fill="white"/>
+<rect x="1" y="1" width="43" height="43.0251" rx="21.5" fill="url(#paint0_radial_722_81)"/>
+<rect x="1" y="1" width="43" height="43.0251" rx="21.5" fill="#FAFAFA"/>
+<rect x="1" y="1" width="43" height="43.0251" rx="21.5" stroke="#56C9C0" stroke-opacity="0.12" stroke-width="0.8"/>
+<path d="M31.4661 13L29.4661 15M29.4661 15L32.4661 18M29.4661 15L25.9661 18.5M21.8561 22.61C22.3724 23.1195 22.7829 23.726 23.0638 24.3948C23.3448 25.0635 23.4907 25.7813 23.4931 26.5066C23.4956 27.232 23.3545 27.9507 23.078 28.6213C22.8015 29.2919 22.3952 29.9012 21.8822 30.4141C21.3693 30.9271 20.76 31.3334 20.0894 31.6099C19.4188 31.8864 18.7001 32.0275 17.9747 32.025C17.2494 32.0226 16.5316 31.8767 15.8629 31.5958C15.1941 31.3148 14.5876 30.9043 14.0781 30.388C13.0762 29.3507 12.5219 27.9614 12.5344 26.5193C12.5469 25.0772 13.1253 23.6977 14.1451 22.678C15.1648 21.6583 16.5443 21.0798 17.9864 21.0673C19.4285 21.0548 20.8178 21.6091 21.8551 22.611L21.8561 22.61ZM21.8561 22.61L25.9661 18.5M25.9661 18.5L28.9661 21.5" stroke="#2DC497" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<defs>
+<radialGradient id="paint0_radial_722_81" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(44 44.0251) rotate(-143.455) scale(72.2562 56.2507)">
+<stop offset="0.285016" stop-color="#F1FAEE"/>
+<stop offset="1" stop-color="#F1FAEE"/>
+</radialGradient>
+</defs>
+</svg>

--- a/src/components/MyPageButton.jsx
+++ b/src/components/MyPageButton.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styles from '../style/Button.module.css';
+import mypage from '../assets/icons/mypage.svg';
+
+const MyPageButton = () => {
+	const changeScene = (scene) => {
+    window.Unity?.call(JSON.stringify({ type: 'scene_change', target: scene }));
+  };
+
+  	return (
+    		<button className={styles.MyPageButton} onClick={() => changeScene('MyPage')}>
+				<img alt="" src={ mypage } />
+    		</button>);
+};
+
+export default MyPageButton;

--- a/src/style/Button.module.css
+++ b/src/style/Button.module.css
@@ -103,3 +103,19 @@
   color: #fafafa;
   font-family: 'Freesentation', sans-serif;
 }
+
+.MyPageButton {
+  width: 43px;
+  height: 43px;
+  position: relative;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+
+  border: none;
+  border-radius: 25px;
+  background: transparent;
+  box-shadow: 0 0 24px rgba(0, 0, 0, 0.28);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 화면 좌측 상단에 ‘마이페이지’ 버튼이 추가되었습니다. 고정 위치로 항상 표시되며, 탭/클릭 시 마이페이지로 이동할 수 있습니다. 기존 우측 상단의 스토어 버튼과 함께 노출됩니다.
- 스타일
  - 새로운 원형 아이콘 버튼 스타일이 추가되어 일관된 크기와 그림자 효과로 가독성과 접근성이 개선되었습니다. 버튼은 화면 상단에 고정되어 쉽게 접근할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->